### PR TITLE
Increase timeouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
+/target
 

--- a/src/test/java/com/redhat/asynch/resource/JaxrsAsyncResource.java
+++ b/src/test/java/com/redhat/asynch/resource/JaxrsAsyncResource.java
@@ -51,7 +51,7 @@ public class JaxrsAsyncResource {
             public void run() {
                 try {
                     logger.info("Timeout thread started.");
-                    Thread.sleep(1000);
+                    Thread.sleep(5000);
                     Response jaxrs = Response.ok("hello").type(MediaType.TEXT_PLAIN).build();
                     response.resume(jaxrs);
                 } catch (Exception e) {

--- a/src/test/java/com/redhat/asynch/resource/LegacySuspendResource.java
+++ b/src/test/java/com/redhat/asynch/resource/LegacySuspendResource.java
@@ -47,7 +47,7 @@ public class LegacySuspendResource {
             @Override
             public void run() {
                 try {
-                    Thread.sleep(1000);
+                    Thread.sleep(5000);
                     Response jaxrs = Response.ok("hello").type(MediaType.TEXT_PLAIN).build();
                     response.resume(jaxrs);
                 } catch (Exception e) {


### PR DESCRIPTION
We are seeing the tests with cxf failing randomly in jenkins.

In my laptop the cxf tests pass with master, but I can make them fail reliably
by decreasing the timeout to 150 or even 500 ms. This suggests that a more loaded/less
powerful VM will fail with 1000ms (current) but will pass with 5000ms.

Tests in our internal jenkins show the tests pass with 5000ms

**Note**: Tests are passing with resteasy as is, and also after increasing the timeout
**Note2**: There is a second timeout related problem that keeps popping up and will be researched separately